### PR TITLE
Added protection from null/undefined parameter to "setOpponentLive" method

### DIFF
--- a/src/Interface.js
+++ b/src/Interface.js
@@ -71,8 +71,7 @@ PrinceJS.Interface.prototype = {
     },
     
     setOpponentLive: function(actor) {
-        
-        if (actor.charName == 'skeleton') return;
+        if (!actor || actor.charName == 'skeleton') return;
         
         this.oppHPActive = actor.health;
         for (var i=actor.health; i > 0; i--) {


### PR DESCRIPTION
I found that when you wait for the first cutscene and credits to pass, the game tries to start the "demo" level 0. But it has no guards[1] defined, so the it crashes leaving this error on the console: 
"phaser.js:74099 TypeError: Cannot read property 'charName' of undefined(…)xhr.onload @ phaser.js:74099"
I added a protection for this case.
